### PR TITLE
Add CentralControl scene support

### DIFF
--- a/custom_components/becker_centralcontrol_has/central_control.py
+++ b/custom_components/becker_centralcontrol_has/central_control.py
@@ -113,6 +113,32 @@ class CentralControl:
             }
         )
 
+    async def get_scene_list(self) -> dict:
+        """Retrieve the list of configured scenes."""
+        return await self.get_item_list(item_type="scene")
+
+    async def scene_invoke(self, scene_id: int) -> dict:
+        """Invoke a configured scene."""
+        return await self._jrpc_request(
+            data={
+                "jsonrpc": "2.0",
+                "id": 0,
+                "params": {"scene_id": scene_id},
+                "method": "deviced.scene_invoke",
+            }
+        )
+
+    async def scene_stop(self, scene_id: int) -> dict:
+        """Stop a configured scene."""
+        return await self._jrpc_request(
+            data={
+                "jsonrpc": "2.0",
+                "id": 0,
+                "params": {"scene_id": scene_id},
+                "method": "deviced.scene_stop",
+            }
+        )
+
     async def group_send_command(self, group_id: int, command: str, value) -> dict:
         """Send a command to a group.
 

--- a/custom_components/becker_centralcontrol_has/const.py
+++ b/custom_components/becker_centralcontrol_has/const.py
@@ -5,7 +5,12 @@ from enum import StrEnum
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.const import Platform
 
-PLATFORMS: list[Platform] = [Platform.COVER, Platform.LIGHT, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.COVER,
+    Platform.LIGHT,
+    Platform.SCENE,
+    Platform.SENSOR,
+]
 DOMAIN = "becker_centralcontrol_has"
 MANUFACTURER = "Becker Antriebe GmbH"
 

--- a/custom_components/becker_centralcontrol_has/scene.py
+++ b/custom_components/becker_centralcontrol_has/scene.py
@@ -1,0 +1,82 @@
+"""Representation of a Scene in the CentralControl."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.scene import Scene
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .central_control import CentralControl
+from .const import DOMAIN, MANUFACTURER
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Glue CentralControl scene items to HASS entities."""
+
+    central_control: CentralControl = entry.runtime_data
+    try:
+        item_list = await central_control.get_scene_list()
+        scene_list = []
+
+        for item in item_list.get("result", {}).get("item_list", []):
+            if item.get("type") == "scene":
+                scene_list.append(
+                    BeckerScene(
+                        central_control=central_control,
+                        item=item,
+                    )
+                )
+
+        async_add_entities(scene_list)
+    except TimeoutError:
+        _LOGGER.error("Failed to get scene list")
+        return
+
+
+class BeckerScene(Scene):
+    """Representation of a Becker scene."""
+
+    def __init__(
+        self,
+        central_control: CentralControl,
+        item: dict,
+    ) -> None:
+        """Initialize the scene."""
+        self._central_control = central_control
+        self._item = item
+
+        self._attr_name = f"{central_control.prefix}{item.get('name', 'Unknown')}"
+        self._attr_unique_id = f"{central_control.prefix}scene_{item.get('id')}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.unique_id)},
+            manufacturer=MANUFACTURER,
+            name=self.name,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        """The scene's unique id."""
+        return str(self._attr_unique_id)
+
+    @property
+    def name(self) -> str:
+        """The scene's name, "Unknown" if None."""
+        return str(self._attr_name)
+
+    async def async_activate(self, **kwargs) -> None:
+        """Activate the scene."""
+        await self._central_control.scene_invoke(scene_id=int(self._item.get("id")))

--- a/tests/test_central_control.py
+++ b/tests/test_central_control.py
@@ -1,0 +1,75 @@
+"""Tests for the CentralControl API client."""
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "becker_centralcontrol_has"
+    / "central_control.py"
+)
+spec = importlib.util.spec_from_file_location("central_control", MODULE_PATH)
+central_control_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(central_control_module)
+CentralControl = central_control_module.CentralControl
+
+
+def _response(payload: dict) -> Mock:
+    response = Mock()
+    response.text = json.dumps(payload) + "\0"
+    response.content = response.text.encode()
+    return response
+
+
+async def test_get_scene_list_fetches_scene_items() -> None:
+    """Fetch configured scenes from the CentralControl."""
+
+    central_control = CentralControl("192.168.1.64")
+
+    with patch.object(
+        central_control_module.requests,
+        "post",
+        return_value=_response({"jsonrpc": "2.0", "id": 0, "result": {}}),
+    ) as post:
+        await central_control.get_scene_list()
+
+    request = json.loads(post.call_args.kwargs["data"].replace("\0", ""))
+    assert request["method"] == "deviced.deviced_get_item_list"
+    assert request["params"] == {"item_type": "scene"}
+
+
+async def test_scene_invoke_sends_scene_command() -> None:
+    """Invoke a configured scene."""
+
+    central_control = CentralControl("192.168.1.64")
+
+    with patch.object(
+        central_control_module.requests,
+        "post",
+        return_value=_response({"jsonrpc": "2.0", "id": 0, "result": {}}),
+    ) as post:
+        await central_control.scene_invoke(109)
+
+    request = json.loads(post.call_args.kwargs["data"].replace("\0", ""))
+    assert request["method"] == "deviced.scene_invoke"
+    assert request["params"] == {"scene_id": 109}
+
+
+async def test_scene_stop_sends_scene_command() -> None:
+    """Stop a configured scene."""
+
+    central_control = CentralControl("192.168.1.64")
+
+    with patch.object(
+        central_control_module.requests,
+        "post",
+        return_value=_response({"jsonrpc": "2.0", "id": 0, "result": {}}),
+    ) as post:
+        await central_control.scene_stop(109)
+
+    request = json.loads(post.call_args.kwargs["data"].replace("\0", ""))
+    assert request["method"] == "deviced.scene_stop"
+    assert request["params"] == {"scene_id": 109}

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,0 +1,132 @@
+"""Tests for CentralControl scene entities."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+import sys
+
+
+def _install_homeassistant_stubs() -> None:
+    """Install minimal Home Assistant stubs needed to import the integration."""
+
+    homeassistant = ModuleType("homeassistant")
+    components = ModuleType("homeassistant.components")
+    scene = ModuleType("homeassistant.components.scene")
+    config_entries = ModuleType("homeassistant.config_entries")
+    const = ModuleType("homeassistant.const")
+    core = ModuleType("homeassistant.core")
+    helpers = ModuleType("homeassistant.helpers")
+    device_registry = ModuleType("homeassistant.helpers.device_registry")
+    entity_platform = ModuleType("homeassistant.helpers.entity_platform")
+    cover = ModuleType("homeassistant.components.cover")
+
+    class Scene:
+        pass
+
+    class ConfigEntry:
+        def __class_getitem__(cls, item):
+            return cls
+
+    class DeviceInfo(dict):
+        pass
+
+    class Platform:
+        COVER = "cover"
+        LIGHT = "light"
+        SCENE = "scene"
+        SENSOR = "sensor"
+
+    class CoverDeviceClass:
+        AWNING = "awning"
+        DOOR = "door"
+        WINDOW = "window"
+        SHUTTER = "shutter"
+        BLIND = "blind"
+        SHADE = "shade"
+
+    scene.Scene = Scene
+    config_entries.ConfigEntry = ConfigEntry
+    const.Platform = Platform
+    core.HomeAssistant = object
+    device_registry.DeviceInfo = DeviceInfo
+    entity_platform.AddEntitiesCallback = object
+    cover.CoverDeviceClass = CoverDeviceClass
+
+    sys.modules.update(
+        {
+            "homeassistant": homeassistant,
+            "homeassistant.components": components,
+            "homeassistant.components.cover": cover,
+            "homeassistant.components.scene": scene,
+            "homeassistant.config_entries": config_entries,
+            "homeassistant.const": const,
+            "homeassistant.core": core,
+            "homeassistant.helpers": helpers,
+            "homeassistant.helpers.device_registry": device_registry,
+            "homeassistant.helpers.entity_platform": entity_platform,
+        }
+    )
+
+
+_install_homeassistant_stubs()
+
+from custom_components.becker_centralcontrol_has.scene import (  # noqa: E402
+    BeckerScene,
+    async_setup_entry,
+)
+
+
+async def test_scene_setup_creates_scene_entities() -> None:
+    """Create HA scene entities from CentralControl scene items."""
+
+    central_control = SimpleNamespace(
+        prefix="",
+        get_scene_list=AsyncMock(
+            return_value={
+                "result": {
+                    "item_list": [
+                        {"id": 109, "type": "scene", "name": "Terrasse AUF"},
+                        {"id": 44, "type": "scene", "name": "Terrasse ZU"},
+                        {"id": 17, "type": "group", "name": "TV Stube"},
+                    ]
+                }
+            }
+        ),
+    )
+    entry = SimpleNamespace(runtime_data=central_control)
+    added_entities = []
+
+    await async_setup_entry(None, entry, added_entities.extend)
+
+    assert [entity.name for entity in added_entities] == ["Terrasse AUF", "Terrasse ZU"]
+    assert [entity.unique_id for entity in added_entities] == ["scene_109", "scene_44"]
+
+
+async def test_scene_setup_empty_list() -> None:
+    """Handle an empty scene list gracefully."""
+
+    central_control = SimpleNamespace(
+        prefix="",
+        get_scene_list=AsyncMock(return_value={"result": {"item_list": []}}),
+    )
+    entry = SimpleNamespace(runtime_data=central_control)
+    added_entities = []
+
+    await async_setup_entry(None, entry, added_entities.extend)
+
+    assert added_entities == []
+
+
+async def test_scene_activate_calls_scene_invoke() -> None:
+    """Activating a HA scene invokes the CentralControl scene."""
+
+    central_control = SimpleNamespace(prefix="", scene_invoke=AsyncMock())
+    scene = BeckerScene(
+        central_control=central_control,
+        item={"id": 109, "type": "scene", "name": "Terrasse AUF"},
+    )
+
+    await scene.async_activate()
+
+    central_control.scene_invoke.assert_awaited_once_with(scene_id=109)


### PR DESCRIPTION
## Summary
- Add `Platform.SCENE` forwarding and a `scene.py` platform
- Import CentralControl `scene` items as Home Assistant `scene.*` entities
- Map HA scene activation to JSON-RPC `deviced.scene_invoke`
- Add JSON-RPC helpers for `get_scene_list`, `scene_invoke`, and `scene_stop`
- Add focused tests for scene setup, activation, and JSON-RPC payloads

## Notes
- Scenes are modeled as stateless HA scenes, not switches. This matches Home Assistant semantics and maps cleanly to `scene.turn_on`.
- `scene_stop` is included as a client helper for future use, but not exposed in HA because scene entities do not have a native stop action. A future `button.*` platform could expose stop commands if desired.

## Testing
- `PYTHONPATH=. uv run --python 3.13 --with pytest --with pytest-cov --with pytest-asyncio --with requests pytest tests/test_central_control.py tests/test_scene.py -q`
- `uv run --python 3.13 --with ruff==0.0.261 ruff check custom_components/becker_centralcontrol_has/central_control.py custom_components/becker_centralcontrol_has/const.py custom_components/becker_centralcontrol_has/scene.py tests/test_central_control.py tests/test_scene.py`

Note: running ruff on the full repository currently fails on pre-existing issues unrelated to this PR: the configured old ruff version cannot parse the Python 3.12 `type` alias in `__init__.py`, and `sensor.py` has an unused import.